### PR TITLE
ADD: link to "Docs" docs.openradarscience.org

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -60,6 +60,14 @@ html_theme = 'pydata_sphinx_theme'
 
 # Add some more theme Options
 html_theme_options = {
+    "external_links": [
+        {
+            "url": "https://docs.openradarscience.org",
+            "name": "Docs",
+        },
+    ],
+    "header_links_before_dropdown": 4,
+    "show_toc_level": 1,
     'github_url': 'https://github.com/openradar/openradar.github.io',
     'search_bar_text': 'Search this site... ',
     "navbar_align": "left",

--- a/index.md
+++ b/index.md
@@ -40,6 +40,6 @@ Have you developed a software for weather radar data processing? We invite you t
 pages/projects
 blog
 pages/workshops
-pages/opendata
 pages/community
+pages/opendata
 ```


### PR DESCRIPTION
This adds a "Docs" entry to the top navigation which points to 

https://docs.openradarscience.org/en/latest/